### PR TITLE
Do not specify Ruby micro version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1.2'
-          - '3.0.2'
+          - '3.1'
+          - '3.0'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
I suspect this might be what's causing builds to fail, let's see if being less specific helps.