### PR TITLE
Upgrade nio4r to v2.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,8 +136,12 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.8)
+    nio4r (2.7.0)
     nokogiri (1.14.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
@@ -227,6 +231,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
It does not compile on my M3 machine, but seems to have been fixed in a later version.

https://github.com/socketry/nio4r/issues/298